### PR TITLE
Fix pull request url access in review comments

### DIFF
--- a/marvin/__main__.py
+++ b/marvin/__main__.py
@@ -169,7 +169,7 @@ async def pull_request_review_comment_event(
     await handle_comment(
         event.data["comment"],
         event.data["pull_request"],
-        event.data["issue"]["pull_request"]["url"],
+        event.data["pull_request"]["url"],
         gh,
         token,
     )
@@ -182,7 +182,7 @@ async def pull_request_review_submitted_event(
     await handle_comment(
         event.data["review"],
         event.data["pull_request"],
-        event.data["issue"]["pull_request"]["url"],
+        event.data["pull_request"]["url"],
         gh,
         token,
     )


### PR DESCRIPTION
Broken by 28717e5af8a9f086279a385debff903b7e4e06a9:

```
Traceback (most recent call last):
File "/app/marvin/__main__.py", line 258, in process_webhook
await router.dispatch(event, gh, installation_access_token["token"])
File "/app/.heroku/python/lib/python3.6/site-packages/gidgethub/routing.py", line 84, in dispatch
await callback(event, *args, **kwargs)
File "/app/marvin/__main__.py", line 185, in pull_request_review_submitted_event
event.data["issue"]["pull_request"]["url"],
KeyError: 'issue'
```