### PR TITLE
Implement rate limiting

### DIFF
--- a/marvin/__main__.py
+++ b/marvin/__main__.py
@@ -133,7 +133,9 @@ async def handle_comment(
                 )
             else:
                 await set_issue_status(issue, "needs_merge", gh, token)
-                reviewer = await get_reviewer(gh, issue, merge_permission_needed=True)
+                reviewer = await get_reviewer(
+                    gh, token, issue, merge_permission_needed=True
+                )
                 if reviewer is not None:
                     print(
                         f"Requesting review (merge) from {reviewer} for {pull_request_url}."

--- a/marvin/gh_util.py
+++ b/marvin/gh_util.py
@@ -1,0 +1,17 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
+from gidgethub.aiohttp import GitHubAPI
+
+
+async def search_issues(gh: GitHubAPI, query_parameters: List[str],) -> Dict[str, Any]:
+    """Search github issues and pull requests.
+
+    As documented here:
+    https://developer.github.com/v3/search/#search-issues-and-pull-requests
+
+    A common query string is likely "repo:NixOS/nixpkgs".
+    """
+    query = "+".join(query_parameters)
+    return await gh.getitem(f"https://api.github.com/search/issues?q={query}")

--- a/marvin/gh_util.py
+++ b/marvin/gh_util.py
@@ -5,7 +5,9 @@ from typing import List
 from gidgethub.aiohttp import GitHubAPI
 
 
-async def search_issues(gh: GitHubAPI, query_parameters: List[str],) -> Dict[str, Any]:
+async def search_issues(
+    gh: GitHubAPI, token: str, query_parameters: List[str],
+) -> Dict[str, Any]:
     """Search github issues and pull requests.
 
     As documented here:
@@ -14,4 +16,6 @@ async def search_issues(gh: GitHubAPI, query_parameters: List[str],) -> Dict[str
     A common query string is likely "repo:NixOS/nixpkgs".
     """
     query = "+".join(query_parameters)
-    return await gh.getitem(f"https://api.github.com/search/issues?q={query}")
+    return await gh.getitem(
+        f"https://api.github.com/search/issues?q={query}", oauth_token=token
+    )

--- a/marvin/team.py
+++ b/marvin/team.py
@@ -16,7 +16,7 @@ class Member:
     def __init__(
         self,
         gh_name: str,
-        request_allowed: Callable[[gh_aiohttp.GitHubAPI], Awaitable[bool]],
+        request_allowed: Callable[[gh_aiohttp.GitHubAPI, str], Awaitable[bool]],
         can_merge: bool = False,
     ):
         self.gh_name = gh_name
@@ -24,9 +24,11 @@ class Member:
         self.can_merge = can_merge
 
 
-async def fetch_gist_content(gh: gh_aiohttp.GitHubAPI, gist_id: str) -> str:
+async def fetch_gist_content(gh: gh_aiohttp.GitHubAPI, token: str, gist_id: str) -> str:
     """Fetch the content of a one-file github gist using the API."""
-    gist_response = await gh.getitem(f"https://api.github.com/gists/{gist_id}")
+    gist_response = await gh.getitem(
+        f"https://api.github.com/gists/{gist_id}", oauth_token=token
+    )
     # We only support one file per gist, just pick the first one
     gist_file = list(gist_response["files"].values())[0]
     return gist_file["content"]
@@ -34,7 +36,7 @@ async def fetch_gist_content(gh: gh_aiohttp.GitHubAPI, gist_id: str) -> str:
 
 def active_prs_below_limit(
     user: str, days: int, limit: int
-) -> Callable[[gh_aiohttp.GitHubAPI], Awaitable[bool]]:
+) -> Callable[[gh_aiohttp.GitHubAPI, str], Awaitable[bool]]:
     """Determine whether a given active PR limit over a timeframe has already been reached.
 
     This searches GitHub for recently active nixpkgs PRs the user is involved
@@ -43,11 +45,12 @@ def active_prs_below_limit(
     for new reviews when your current open-source work "plate" is not yet full.
     """
 
-    async def decision_function(gh: gh_aiohttp.GitHubAPI) -> bool:
+    async def decision_function(gh: gh_aiohttp.GitHubAPI, token: str) -> bool:
         # days-1 since today is automatically counted
         timeframe_start = (date.today() - timedelta(days=days - 1)).strftime("%Y-%m-%d")
         search_results = await gh_util.search_issues(
             gh,
+            token,
             query_parameters=[
                 "repo:NixOS/nixpkgs",
                 "involves:timokau",
@@ -60,7 +63,9 @@ def active_prs_below_limit(
     return decision_function
 
 
-def gist_controlled(gist_id: str) -> Callable[[gh_aiohttp.GitHubAPI], Awaitable[bool]]:
+def gist_controlled(
+    gist_id: str,
+) -> Callable[[gh_aiohttp.GitHubAPI, str], Awaitable[bool]]:
     """Make a decision function that defers its decision to a github gist.
 
     This enables decentralized control. People can decide to enable or disable
@@ -68,8 +73,8 @@ def gist_controlled(gist_id: str) -> Callable[[gh_aiohttp.GitHubAPI], Awaitable[
     process.
     """
 
-    async def control_function(gh: gh_aiohttp.GitHubAPI) -> bool:
-        return (await fetch_gist_content(gh, gist_id)).strip() == "enable"
+    async def control_function(gh: gh_aiohttp.GitHubAPI, token: str) -> bool:
+        return (await fetch_gist_content(gh, token, gist_id)).strip() == "enable"
 
     return control_function
 
@@ -88,7 +93,10 @@ TEAM = {
 
 
 async def get_reviewer(
-    gh: gh_aiohttp.GitHubAPI, issue: Dict[str, Any], merge_permission_needed: bool
+    gh: gh_aiohttp.GitHubAPI,
+    token: str,
+    issue: Dict[str, Any],
+    merge_permission_needed: bool,
 ) -> Optional[str]:
     """Attempt to find a random reviewer that is currently allowing requests."""
 
@@ -109,7 +117,7 @@ async def get_reviewer(
             print(f"Skipping pr author {pr_author_login}")
             continue
         print(f"Testing {candidate.gh_name}")
-        if await candidate.request_allowed(gh):
+        if await candidate.request_allowed(gh, token):
             return candidate.gh_name
 
     return None


### PR DESCRIPTION
This implements rate limiting based on the amount of PRs somebody is
currently already involved in. We don't want to request reviews from
people that are already overwhelmed. That is not good for them and not
good for the reviews.