### PR TITLE
Review request fix

### DIFF
--- a/marvin/__main__.py
+++ b/marvin/__main__.py
@@ -54,6 +54,18 @@ def is_opted_in(event: sansio.Event) -> bool:
     return False
 
 
+def log_event(event: sansio.Event) -> None:
+    action = event.data.get("action")
+    number = (
+        event.data["issue"]["number"]
+        if "issue" in event.data
+        else event.data["pull_request"]
+        if "pull_request" in event.data
+        else None
+    )
+    print(f"New event: #{number} {event.event}->{action}")
+
+
 @routes.post("/webhook")
 async def process_webhook(request: web.Request) -> web.Response:
     try:
@@ -94,14 +106,7 @@ async def process_webhook(request: web.Request) -> web.Response:
                 triage_runner.runners[installation_id].start()
 
             if is_opted_in(event) and not is_bot_comment(event):
-                if "issue" in event.data:
-                    print(f"New event on #{event.data['issue']['number']}")
-                elif "pull_request" in event.data:
-                    print(f"New event on #{event.data['pull_request']['number']}")
-                else:
-                    print(
-                        f"New event that couldn't be assigned to an issue or PR: {event}"
-                    )
+                log_event(event)
                 # call the appropriate callback for the event
                 await router.dispatch(event, gh, installation_access_token["token"])
 

--- a/marvin/commands.py
+++ b/marvin/commands.py
@@ -6,6 +6,7 @@ from gidgethub import routing
 from gidgethub import sansio
 from gidgethub.aiohttp import GitHubAPI
 
+from marvin import gh_util
 from marvin import status
 from marvin import triage
 from marvin.command_router import CommandRouter
@@ -40,9 +41,7 @@ async def handle_comment(
             await gh.post(
                 issue_url + "/labels", data={"labels": ["marvin"]}, oauth_token=token,
             )
-            await gh.post(
-                issue["comments_url"], data={"body": GREETING}, oauth_token=token,
-            )
+            gh_util.post_comment(gh, token, issue["comments_url"], GREETING)
         else:
             return
 

--- a/marvin/gh_util.py
+++ b/marvin/gh_util.py
@@ -23,6 +23,13 @@ async def request_review(
     await gh.post(url, data={"reviewers": [gh_login]}, oauth_token=token)
 
 
+async def post_comment(gh: GitHubAPI, token: str, comments_url: str, body: str) -> None:
+    """Post a new comment."""
+    await gh.post(
+        comments_url, data={"body": body}, oauth_token=token,
+    )
+
+
 async def num_search_results(
     gh: GitHubAPI, token: str, query_parameters: List[str],
 ) -> int:

--- a/marvin/triage.py
+++ b/marvin/triage.py
@@ -89,8 +89,8 @@ async def assign_mergers(gh: GitHubAPI, token: str, repository_name: str) -> Non
         )
         if reviewer is not None:
             print(f"Requesting review (merge) from {reviewer} for #{issue['number']}.")
-            await gh_util.request_review(
-                issue["pull_request"]["url"], reviewer, gh, token
+            await gh_util.request_review_fallback(
+                gh, token, issue["pull_request"]["url"], issue["comments_url"], reviewer
             )
             await set_issue_status(issue, "awaiting_merger", gh, token)
         else:


### PR DESCRIPTION
I forgot that you can only request reviews from people who are in some way a member of the organization. We could ask every reviewer to sign up as a Maintainer instead, but this fallback can't hurt.