### PR TITLE
Do not transition to awaiting_changes on comments

### DIFF
--- a/marvin/status.py
+++ b/marvin/status.py
@@ -56,11 +56,6 @@ async def issue_comment_event(
             # A new comment by the author is probably some justification or request
             # for clarification. Action of the reviewer is needed.
             await gh_util.set_issue_status(issue, "awaiting_reviewer", gh, token)
-    else:
-        # A new comment by somebody else is likely a review asking for
-        # clarification or changes (provided it doesn't explicitly contain a
-        # status command).
-        await gh_util.set_issue_status(issue, "awaiting_changes", gh, token)
 
 
 @router.register("pull_request_review", action="submitted")

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -68,29 +68,6 @@ async def test_removes_old_status_labels_on_new_status() -> None:
     }
 
 
-async def test_sets_to_awaiting_changes_on_non_author_comment() -> None:
-    data = {
-        "action": "created",
-        "issue": {
-            "url": "issue-url",
-            "pull_request": {"url": "pr-url"},
-            "user": {"id": 42, "login": "author"},
-            "labels": [{"name": "marvin"}, {"name": "needs_merger"}],
-        },
-        "comment": {
-            "body": "The body is irrelevant.",
-            "user": {"id": 43, "login": "non-author"},
-        },
-    }
-    event = sansio.Event(data, event="issue_comment", delivery_id="1")
-    gh = GitHubAPIMock()
-    await main.router.dispatch(event, gh, token="fake-token")
-    assert gh.post_data == [("issue-url/labels", {"labels": ["awaiting_changes"]})]
-    assert set(gh.delete_urls) == {
-        "issue-url/labels/needs_merger",
-    }
-
-
 async def test_sets_awaiting_changes_to_awaiting_review_on_author_comment() -> None:
     data = {
         "action": "created",


### PR DESCRIPTION
We want to avoid putting PRs into the "sink" status by accident.
awaiting_changes PRs are not triaged. See
https://github.com/timokau/marvin-mk2/issues/44