### PR TITLE
Fix greeting and triage

### DIFF
--- a/marvin/commands.py
+++ b/marvin/commands.py
@@ -41,7 +41,7 @@ async def handle_comment(
             await gh.post(
                 issue_url + "/labels", data={"labels": ["marvin"]}, oauth_token=token,
             )
-            gh_util.post_comment(gh, token, issue["comments_url"], GREETING)
+            await gh_util.post_comment(gh, token, issue["comments_url"], GREETING)
         else:
             return
 


### PR DESCRIPTION
The greeting is broken (https://github.com/NixOS/nixpkgs/pull/92705#issuecomment-655461733) due to the missing await, the triage has a race condition where sometimes the newly labeled PRs don't turn up in the search (https://github.com/NixOS/nixpkgs/pull/90245). Let's see if 5 seconds is sufficient.