### PR TITLE
 Fix review rate limiting and review request race condition

### DIFF
--- a/marvin/gh_util.py
+++ b/marvin/gh_util.py
@@ -4,6 +4,7 @@ from typing import AsyncGenerator
 from typing import Callable
 from typing import Dict
 from typing import List
+import urllib
 
 import gidgethub
 from gidgethub.aiohttp import GitHubAPI
@@ -76,7 +77,7 @@ def search_issues(
     A common query string is likely "repo:NixOS/nixpkgs". Returns an async
     iterator of issues, automatically handling pagination.
     """
-    query = "+".join(query_parameters)
+    query = "+".join([urllib.parse.quote(param, safe="") for param in query_parameters])
     return gh.getiter(
         f"https://api.github.com/search/issues?q={query}", oauth_token=token
     )

--- a/marvin/status.py
+++ b/marvin/status.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 from typing import Dict
 
@@ -112,6 +113,7 @@ async def needs_reviewer_command(
     gh: GitHubAPI, event: sansio.Event, token: str, issue: Dict[str, Any], **kwargs: Any
 ) -> None:
     await gh_util.set_issue_status(issue, "needs_reviewer", gh, token)
+    await asyncio.sleep(2)  # Make sure the new label has "set".
     triage_runner.runners[event.data["installation"]["id"]].run_soon(gh, token)
 
 


### PR DESCRIPTION
GitHub search parameters need to be urlencoded. Otherwise the newly
introduced UTC offsets (+00:00) are interpreted as separate query
parameters, breaking the rate limiting system.